### PR TITLE
Fixed the problem with the first use example

### DIFF
--- a/python/bob/__init__.py
+++ b/python/bob/__init__.py
@@ -52,3 +52,4 @@ __all__ = [
 
 if has_visioner: __all__.append('visioner')
 if has_daq: __all__.append('daq')
+version = __import__('pkg_resources').require('bob')[0]

--- a/python/doc/TutorialsIntro.rst
+++ b/python/doc/TutorialsIntro.rst
@@ -46,7 +46,7 @@ Here is an example:
   $ python
   ...
   >>> import bob
-  >>> print bob.build.version
+  >>> print bob.version
 
 .. If you decided to use |project| from the build location (without
 .. properly installing it) or 
@@ -63,7 +63,7 @@ Example:
   $ PYTHONPATH=<your-bob-build>/lib/python2.6 python2.6
   ...
   >>> import bob
-  >>> print bob.build.version
+  >>> print bob.version
 
 |project| also includes some executables that are immediately usable after installation. For
 example, to print the version details of your |project| installation, just run:


### PR DESCRIPTION
Created the variable version in the bob namespace which contains the version of bob (imported from the package resources). 
Fixed the tutorial too.
