### PR TITLE
build error: ‘memcpy’ was not declared in this scope

### DIFF
--- a/src/ip/cxx/VLDSIFT.cc
+++ b/src/ip/cxx/VLDSIFT.cc
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstring> //for memcpy
 #include "bob/ip/VLDSIFT.h"
 
 #include "bob/core/assert.h"
@@ -132,7 +133,7 @@ void bob::ip::VLDSIFT::operator()(const blitz::Array<float,2>& src,
   float const *descrs = vl_dsift_get_descriptors(m_filt);
   if(bob::core::array::isCZeroBaseContiguous(dst)) 
     // fast copy
-    memcpy(dst.data(), descrs, num_frames*descr_size);
+    std::memcpy(dst.data(), descrs, num_frames*descr_size);
   else
   {
     // Iterate (slow...)


### PR DESCRIPTION
using this compiler:
    gcc version 4.4.5 (Debian 4.4.5-8)
    Target: x86_64-linux-gnu

build failed:

```
/home/campr/metacentrum/bob-1.1.3_src/src/ip/cxx/VLDSIFT.cc: In member function ‘void bob::ip::VLDSIFT::operator()(const blitz::Array<float, 2>&, blitz::Array<float, 2>&)’:
/home/campr/metacentrum/bob-1.1.3_src/src/ip/cxx/VLDSIFT.cc:135: error: ‘memcpy’ was not declared in this scope
```

this PR fixes the problem
